### PR TITLE
Add dsv for PYTHONPATH for Jetty packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ if(NOT ${${LIB_NAME_FULL}_FOUND})
   # See https://github.com/ament/ament_package/issues/145
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh "# Dummy .sh file needed for .dsv file to be sourced.")
   ament_environment_hooks("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh")
+  # environment hook for setting PYTHONPATH
+  ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_pythonpath.dsv.in")
 endif()
 
 ament_package()

--- a/gz_plugin_vendor.dsv.in
+++ b/gz_plugin_vendor.dsv.in
@@ -1,5 +1,1 @@
 prepend-non-duplicate-if-exists;GZ_CONFIG_PATH;opt/@PROJECT_NAME@/share/gz
-{% # only set PYTHONPATH for unversioned packages (Jetty and newer) %}
-{% if not versioned_package_name %}
-prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python
-{% endif %}

--- a/gz_plugin_vendor.dsv.in
+++ b/gz_plugin_vendor.dsv.in
@@ -1,1 +1,5 @@
 prepend-non-duplicate-if-exists;GZ_CONFIG_PATH;opt/@PROJECT_NAME@/share/gz
+{% # only set PYTHONPATH for unversioned packages (Jetty and newer) %}
+{% if not versioned_package_name %}
+prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python
+{% endif %}

--- a/gz_plugin_vendor_pythonpath.dsv.in
+++ b/gz_plugin_vendor_pythonpath.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python


### PR DESCRIPTION
Part of gazebo-tooling/gz_vendor#2.

Note that this `dsv` is added to all packages but should have no effect if the package doesn't install anything to `lib/python`.